### PR TITLE
Add ability to set M1 and M2 gains via webapp

### DIFF
--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -106,6 +106,18 @@
             </div>
             <div class="row">
                 <div class='col-lg-6'>
+                    <form class="form-inline">
+                        <div class="form-group">
+                            <label for="m1gain">M1 Gain:</label>
+                            <input type="text" default="0.5" id="m1gain">
+                            <label for="m2gain">M2 Gain:</label>
+                            <input type="text" default="1.0" id="m2gain">
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <div class="row">
+                <div class='col-lg-6'>
                     <button type="button" id='focuscorrect' data-loading-text="Running..." class="btn btn-primary">Correct Focus</button>
                     <button type="button" id='comacorrect' data-loading-text="Running..." class="btn btn-primary">Correct Coma</button>
                     <button type="button" id='m1correct' data-loading-text="Running..." class="btn btn-primary">Correct M1</button>

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -109,9 +109,10 @@
                     <form class="form-inline">
                         <div class="form-group">
                             <label for="m1gain">M1 Gain:</label>
-                            <input type="text" default="0.5" id="m1gain">
+                            <input type="number" min=0.0 max=1.0 step=0.1 value="{{ m1_gain }}" id="m1gain">
                             <label for="m2gain">M2 Gain:</label>
-                            <input type="text" default="1.0" id="m2gain">
+                            <input type="number" min=0.0 max=1.0 step=0.1 value="{{ m2_gain }}" id="m2gain">
+                            <button type="button" id='setgains' data-loading-text="Running..." class="btn btn-primary">Set Gains</button>
                         </div>
                     </form>
                 </div>
@@ -165,6 +166,28 @@
             var $btn = $(this).button('loading');
             $.get("recenter", function(data, status) {
                 alert(data);
+            });
+            $btn.button('reset');
+        });
+        $('#setgains').on('click', function() {
+            var $btn = $(this).button('loading');
+            var m1g = $('#m1gain').val();
+            var m2g = $('#m2gain').val();
+            var m1url = "m1gain";
+            var m2url = "m2gain";
+            $.ajax({
+                url: m1url,
+                method: 'POST',
+                data: {
+                    'gain': m1g
+                }
+            });
+            $.ajax({
+                url: m2url,
+                method: 'POST',
+                data: {
+                    'gain': m2g
+                }
             });
             $btn.button('reset');
         });

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -106,9 +106,9 @@
             </div>
             <div class="row">
                 <div class='col-lg-6'>
-                    <button type="button" id='m2correct' data-loading-text="Running..." class="btn btn-primary">Correct M2</button>
+                    <button type="button" id='focuscorrect' data-loading-text="Running..." class="btn btn-primary">Correct Focus</button>
+                    <button type="button" id='comacorrect' data-loading-text="Running..." class="btn btn-primary">Correct Coma</button>
                     <button type="button" id='m1correct' data-loading-text="Running..." class="btn btn-primary">Correct M1</button>
-                    <button type="button" id='recenter' data-loading-text="Running..." class="btn btn-primary">Recenter</button>
                 </div>
             </div>
         </div>

--- a/wfssrv/wfssrv.py
+++ b/wfssrv/wfssrv.py
@@ -123,7 +123,9 @@ class WFSServ(tornado.web.Application):
                         figures=figkeys,
                         datadir=self.application.datadir + "/",
                         modes=self.application.wfs.modes,
-                        default_mode=self.application.wfs.default_mode
+                        default_mode=self.application.wfs.default_mode,
+                        m1_gain=self.application.wfs.m1_gain,
+                        m2_gain=self.application.wfs.m2_gain
                     )
             except Exception as e:
                 log.warn("Must specify valid wfs: %s. %s" % (wfs, e))
@@ -318,16 +320,18 @@ class WFSServ(tornado.web.Application):
                 self.write("no WFS selected.")
 
         def post(self):
+            self.set_header("Content-Type", "text/plain")
             try:
-                gain = float(self.get_argument(gain))
+                gain = float(self.get_body_argument('gain'))
                 if self.application.wfs is not None:
                     if gain >= 0.0 and gain <= 1.0:
                         self.application.wfs.m1_gain = gain
                     else:
                         log.warn("Invalid M1 gain: %f" % gain)
-                    log.info("Seeing M1 gain to %f" % gain)
-            except:
-                log.info("No M1 gain specified")
+                    log.info("Setting M1 gain to %f" % gain)
+            except Exception as e:
+                log.warn("No M1 gain specified: %s" % e)
+                log.info("Body: %s" % self.request.body)
 
     class M2GainHandler(tornado.web.RequestHandler):
         def get(self):
@@ -337,16 +341,18 @@ class WFSServ(tornado.web.Application):
                 self.write("no WFS selected.")
 
         def post(self):
+            self.set_header("Content-Type", "text/plain")
             try:
-                gain = float(self.get_argument(gain))
+                gain = float(self.get_body_argument('gain'))
                 if self.application.wfs is not None:
                     if gain >= 0.0 and gain <= 1.0:
                         self.application.wfs.m2_gain = gain
                     else:
                         log.warn("Invalid M2 gain: %f" % gain)
-                    log.info("Seeing M2 gain to %f" % gain)
-            except:
-                log.info("No M2 gain specified")
+                    log.info("Setting M2 gain to %f" % gain)
+            except Exception as e:
+                log.warn("No M2 gain specified: %s" % e)
+                log.info("Body: %s" % self.request.body)
 
     class PendingHandler(tornado.web.RequestHandler):
         def get(self):

--- a/wfssrv/wfssrv.py
+++ b/wfssrv/wfssrv.py
@@ -321,10 +321,13 @@ class WFSServ(tornado.web.Application):
             try:
                 gain = float(self.get_argument(gain))
                 if self.application.wfs is not None:
-                    self.application.wfs.m1_gain = gain
+                    if gain >= 0.0 and gain <= 1.0:
+                        self.application.wfs.m1_gain = gain
+                    else:
+                        log.warn("Invalid M1 gain: %f" % gain)
                     log.info("Seeing M1 gain to %f" % gain)
             except:
-                log.info("no m1_gain specified")
+                log.info("No M1 gain specified")
 
     class M2GainHandler(tornado.web.RequestHandler):
         def get(self):
@@ -337,10 +340,13 @@ class WFSServ(tornado.web.Application):
             try:
                 gain = float(self.get_argument(gain))
                 if self.application.wfs is not None:
-                    self.application.wfs.m2_gain = gain
+                    if gain >= 0.0 and gain <= 1.0:
+                        self.application.wfs.m2_gain = gain
+                    else:
+                        log.warn("Invalid M2 gain: %f" % gain)
                     log.info("Seeing M2 gain to %f" % gain)
             except:
-                log.info("no m2_gain specified")
+                log.info("No M2 gain specified")
 
     class PendingHandler(tornado.web.RequestHandler):
         def get(self):


### PR DESCRIPTION
This PR only affects the webapp components and adds the ability to set/get the M1 and M2 gains via the web interface.  It also splits focus and coma corrections into separate callbacks with separate buttons.  There are many cases where the focus determination may be valid, but coma and M1 errors may not be.  Coma corrections are now subject to the same fit quality threshold as M1 corrections while focus corrections have a much looser tolerance. 