### PR TITLE
Add continuous WFS support to web interface

### DIFF
--- a/mmtwfs/config.py
+++ b/mmtwfs/config.py
@@ -264,7 +264,7 @@ mmt_config = {
             "find_thresh": 5.0,
             "rotation": 180. * u.deg,  # this is referenced to camera2. camera1 is camera2+180, but is flipped by image acq
             "pix_size": 0.156 * u.arcsec,
-            "pup_size": 335,  # pixels
+            "pup_size": 325,  # pixels
             "pup_inner": 50,
             "m1_gain": 0.5,  # default gain to apply to primary mirror corrections
             "m2_gain": 1.0,  # default gain to apply to secondary mirror corrections

--- a/mmtwfs/tests/test_wfs.py
+++ b/mmtwfs/tests/test_wfs.py
@@ -72,7 +72,7 @@ def test_mmirs_analysis():
     results = mmirs.measure_slopes(test_file)
     zresults = mmirs.fit_wavefront(results)
     testval = int(zresults['zernike']['Z10'].value)
-    assert((testval > -280) & (testval < -270))
+    assert((testval > -260) & (testval < -250))
 
 @cleanup
 def test_f9_analysis():

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -273,6 +273,12 @@
                 var logstuff = data + status;
                 if (continuous == false) {
                     enable();
+                } else {
+                    if ($('#connect').prop("checked")) {
+                        $('#focuscorrect').trigger('click');
+                        $('#comacorrect').trigger('click');
+                        $('#m1correct').trigger('click');
+                    };
                 };
                 $('#analyze').text("Analyze");
             });

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -83,13 +83,14 @@
         <div class="container-fluid">
             <p>
                 <div class="row">
-                    <div class='col-lg-5'>
+                    <div class='col-lg-6'>
                         <label for="datafile"><b>FITS file to analyze:</b></label>
                         <div class="input-group">
                             <span class="input-group-addon" id="datadir">{{ datadir }}</span>
                             <input type="text" class="form-control" id="datafile" aria-describedby="datadir">
                             <span class="input-group-btn">
                                 <button class="btn btn-primary" id='analyze' type="button">Analyze</button>
+                                <button class="btn btn-primary" id='latest' type="button">Analyse Latest</button>
                             </span>
                         </div>
                     </div>
@@ -245,7 +246,7 @@
                 }
             });
         });
-        var controlButtons = ["m1correct", "focuscorrect", "comacorrect", "clear", "analyze"];
+        var controlButtons = ["m1correct", "focuscorrect", "comacorrect", "clear", "analyze", "latest"];
         function enable() {
             $.each(controlButtons, function(i, v) {
                 $('#' + v).prop("disabled", false);
@@ -277,6 +278,15 @@
             });
             $.getJSON("zfit", {format: "json"}).done(function(data) {
                 $('#zernikes').text(data);
+            });
+        });
+        $('#latest').on('click', function() {
+            $.getJSON("files", {format: "json"}).done(function(data) {
+                if (data.length > 0) {
+                    latest_file = data[0];
+                    $('#datafile').val(latest_file);
+                    $('#analyze').trigger('click');
+                };
             });
         });
         function doNextFile() {

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -12,6 +12,12 @@
         <link rel="stylesheet" href="{{ static_url("jquery-ui/themes/smoothness/jquery-ui.min.css") }}" >
         <link rel="stylesheet" href="{{ static_url("css/bootstrap.min.css") }}" type="text/css">
         <link rel="stylesheet" href="{{ static_url("css/bootstrap-theme.min.css") }}" type="text/css" />
+        <style type="text/css">
+            .form-inline label {
+              margin-left: 15px;
+              margin-right: 5px;
+            }
+        </style>
         <script src="{{ static_url("js/jquery-1.11.3.min.js") }}"></script>
         <script src="{{ static_url("js/jquery-ui.min.js") }}"></script>
         <script src="{{ static_url("js/bootstrap.min.js") }}"></script>
@@ -62,7 +68,7 @@
     </head>
 
     <body>
-        <div class="page-header">
+        <div class="page-header" align="center">
             <h1>{{ wfsname }}</h1>
         </div>
 
@@ -83,7 +89,7 @@
                             <span class="input-group-addon" id="datadir">{{ datadir }}</span>
                             <input type="text" class="form-control" id="datafile" aria-describedby="datadir">
                             <span class="input-group-btn">
-                                <button class="btn btn-primary" data-loading-text="Running..." id='analyze' type="button">Analyze</button>
+                                <button class="btn btn-primary" id='analyze' type="button">Analyze</button>
                             </span>
                         </div>
                     </div>
@@ -146,9 +152,34 @@
                     </div>
                 </div>
             </p>
+                {% if wfsname == "MMIRS WFS" %}
+                    <p>
+                        <div class="row">
+                            <div class='col-lg-6 align-self-center'>
+                                <div class='col-lg-4'>
+                                    <button type="button" id='continuous' class="btn btn-primary">Start Continuous WFS</button>
+                                </div>
+                                <div class='col-lg-8'>
+                                    <form class="form-inline">
+                                        <div class="form-group">
+                                            <label class="form-check-label" for="turbo">Turbo Mode:</label>
+                                            <input type="checkbox" id="turbo">
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </p>
+                {% end %}
         </div>
 
         <script>
+        var continuous = false;
+        var orig_m1g = 0.5;
+        var orig_m2g = 1.0;
+        var timer = undefined;
+        var ready = false;
+        var latest_file = "";
         $(function() {
             var getData = function(request, response) {
                 $.getJSON(
@@ -214,9 +245,19 @@
                 }
             });
         });
-        var controlButtons = ["m1correct", "focuscorrect", "comacorrect"];
+        var controlButtons = ["m1correct", "focuscorrect", "comacorrect", "clear", "analyze"];
+        function enable() {
+            $.each(controlButtons, function(i, v) {
+                $('#' + v).prop("disabled", false);
+            });
+        };
+        function disable() {
+            $.each(controlButtons, function(i, v) {
+                $('#' + v).prop("disabled", true);
+            });
+        };
         $('#analyze').on('click', function() {
-            var $btn = $(this).button('loading');
+            $(this).text("Running...");
             var file = $('#datafile').val();
             var dir = $('#datadir').html();
             var mode = $('#mode').val();
@@ -225,18 +266,65 @@
                 var url = "analyze?connect=" + connect + "&fitsfile=" + dir + file;
             } else {
                 var url = "analyze?connect=" + connect + "&mode=" + mode + "&fitsfile=" + dir + file;
-            }
+            };
+            disable();
             $.get(url, function(data, status) {
                 var logstuff = data + status;
-                $.each(controlButtons, function(i, v) {
-                    $('#' + v).prop("disabled", false);
-                })
-                $btn.button('reset');
+                if (continuous == false) {
+                    enable();
+                };
+                $('#analyze').text("Analyze");
             });
             $.getJSON("zfit", {format: "json"}).done(function(data) {
                 $('#zernikes').text(data);
             });
         });
+        function doNextFile() {
+            $.getJSON("files", {format: "json"}).done(function(data) {
+                if (data.length > 0) {
+                    if (data[0] != latest_file) {
+                        latest_file = data[0];
+                        $('#datafile').val(latest_file);
+                        $('#analyze').trigger('click');
+                    };
+                };
+                timer = setTimeout(doNextFile, 1000);
+            });
+        };
+        $('#continuous').on('click', function() {
+            var turbo = $('#turbo').prop("checked");
+            latest_file = $('#datafile').val();
+            if (continuous == false) {
+                $.getJSON("files", {format: "json"}).done(function(data) {
+                    if (data.length > 0) {
+                        if (data[0] != latest_file) {
+                            latest_file = data[0];
+                        };
+                    };
+                });
+                timer = setTimeout(doNextFile, 1000);
+                $(this).text("Stop Continous WFS");
+                disable();
+                continuous = true;
+                if (turbo != true) {
+                    $('#m1gain').val(0.1);
+                    $('#m2gain').val(0.1);
+                    $('#setgains').trigger('click');
+                };
+            } else {
+                $(this).text("Start Continuous WFS");
+                enable();
+                continuous = false;
+                if (timer != undefined) {
+                    clearTimeout(timer);
+                    timer = undefined;
+                }
+                $('#m1gain').val(orig_m1g);
+                $('#m2gain').val(orig_m2g);
+                $('#setgains').trigger('click');
+            };
+        });
+
         </script>
 
         <p>

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -65,16 +65,16 @@
                     var $log = $('#log');
                     var log_ws = new WebSocket('{{ log_uri }}');
                     log_ws.onopen = function() {
-                        $log.append("Logging started...<br/>");
+                        $log.append("<span class='text-primary'>Logging started...</span><br/>");
                     };
                     log_ws.onmessage = function(ev) {
                         $log.append(ev.data);
                     };
                     log_ws.onclose = function(ev) {
-                        $log.append("Logging closed...<br/>");
+                        $log.append("<span class='text-primary'>Logging closed...</span><br/>");
                     };
                     log_ws.onerror = function(ev) {
-                        $log.append("Logging error!!!<br/>");
+                        $log.append("<b><span class='text-danger'>Logging error!!!</span><br/>");
                     };
                 }
             );

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -33,7 +33,11 @@
                     window.open('download_{{ figure }}.' + format, '_blank');
                 };
             {% end %}
-
+            function getZerns() {
+                $.getJSON("zfit", {format: "json"}).done(function(data) {
+                     $('#zernikes').text(data);
+                 });
+            };
             $(document).ready(
                 function() {
                     /* It is up to the application to provide a websocket that the figure
@@ -57,9 +61,8 @@
                             $('div#{{ figure }}')
                         );
                     {% end %}
-                    $.getJSON("zfit", {format: "json"}).done(function(data) {
-                        $('#zernikes').text(data);
-                    });
+
+                    getZerns();
 
                     /* set up websocket for log streaming */
                     var $log = $('#log');
@@ -284,8 +287,7 @@
                 var url = "analyze?connect=" + connect + "&mode=" + mode + "&fitsfile=" + dir + file;
             };
             disable();
-            $.get(url, function(data, status) {
-                var logstuff = data + status;
+            $.getJSON(url, {format: "json"}).done(function(data, status) {
                 if (continuous == false) {
                     enable();
                 } else {
@@ -296,8 +298,6 @@
                     };
                 };
                 $('#analyze').text("Analyze");
-            });
-            $.getJSON("zfit", {format: "json"}).done(function(data) {
                 $('#zernikes').text(data);
             });
         });
@@ -355,7 +355,6 @@
                 $('#setgains').trigger('click');
             };
         });
-
         </script>
 
         <p>
@@ -363,7 +362,7 @@
             <div>
                 <ul class="nav nav-tabs" role="tablist">
                     <li role="presentation" class="active"><a href="#slopes" aria-controls="slopes" role="tab" data-toggle="tab">Slopes/Residuals</a></li>
-                    <li role="presentation"><a href="#zernfit" aria-controls="zernfit" role="tab" data-toggle="tab">Wavefront Fit</a></li>
+                    <li role="presentation"><a href="#zernfit" aria-controls="zernfit" role="tab" data-toggle="tab" onClick="getZerns()">Wavefront Fit</a></li>
                     <li role="presentation"><a href="#zerns" aria-controls="zerns" role="tab" data-toggle="tab">RMS Wavefront Errors</a></li>
                     <li role="presentation"><a href="#wavefront" aria-controls="wavefront" role="tab" data-toggle="tab">Wavefront Map/PSF</a></li>
                     <li role="presentation"><a href="#cell" aria-controls="cell" role="tab" data-toggle="tab">Cell Forces</a></li>

--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -60,6 +60,22 @@
                     $.getJSON("zfit", {format: "json"}).done(function(data) {
                         $('#zernikes').text(data);
                     });
+
+                    /* set up websocket for log streaming */
+                    var $log = $('#log');
+                    var log_ws = new WebSocket('{{ log_uri }}');
+                    log_ws.onopen = function() {
+                        $log.append("Logging started...<br/>");
+                    };
+                    log_ws.onmessage = function(ev) {
+                        $log.append(ev.data);
+                    };
+                    log_ws.onclose = function(ev) {
+                        $log.append("Logging closed...<br/>");
+                    };
+                    log_ws.onerror = function(ev) {
+                        $log.append("Logging error!!!<br/>");
+                    };
                 }
             );
         </script>
@@ -153,25 +169,23 @@
                     </div>
                 </div>
             </p>
-                {% if wfsname == "MMIRS WFS" %}
-                    <p>
-                        <div class="row">
-                            <div class='col-lg-6 align-self-center'>
-                                <div class='col-lg-4'>
-                                    <button type="button" id='continuous' class="btn btn-primary">Start Continuous WFS</button>
-                                </div>
-                                <div class='col-lg-8'>
-                                    <form class="form-inline">
-                                        <div class="form-group">
-                                            <label class="form-check-label" for="turbo">Turbo Mode:</label>
-                                            <input type="checkbox" id="turbo">
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
+            <p>
+                <div class="row">
+                    <div class='col-lg-6 align-self-center'>
+                        <div class='col-lg-4'>
+                            <button type="button" id='continuous' class="btn btn-primary">Start Continuous WFS</button>
                         </div>
-                    </p>
-                {% end %}
+                        <div class='col-lg-8'>
+                            <form class="form-inline">
+                                <div class="form-group">
+                                    <label class="form-check-label" for="turbo">Turbo Mode:</label>
+                                    <input type="checkbox" id="turbo">
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </p>
         </div>
 
         <script>
@@ -181,6 +195,7 @@
         var timer = undefined;
         var ready = false;
         var latest_file = "";
+        var skip_next = false;
         $(function() {
             var getData = function(request, response) {
                 $.getJSON(
@@ -416,5 +431,12 @@
                 </div>
             </div>
         </p>
+        <hr>
+        <div class='row'>
+            <div class='col-lg-12'>
+                <div id="log" class="well well-lg pre-scrollable" style="height: 200px; overflow: scroll">
+                </div>
+            </div>
+        </div>
     </body>
 </html>

--- a/wfssrv/wfssrv.py
+++ b/wfssrv/wfssrv.py
@@ -7,6 +7,7 @@ import os
 import socket
 import glob
 import json
+import pathlib
 
 import logging
 import logging.handlers
@@ -382,11 +383,11 @@ class WFSServ(tornado.web.Application):
 
     class FilesHandler(tornado.web.RequestHandler):
         def get(self):
-            fullfiles = glob.glob(os.path.join(self.application.datadir, "*.fits"))
+            p = pathlib.Path(self.application.datadir)
+            fullfiles = sorted(p.glob("*_*.fits"), key=lambda x: x.stat().st_mtime)
             files = []
             for f in fullfiles:
-                files.append(os.path.split(f)[1])
-            files.sort()
+                files.append(f.name)
             files.reverse()
             self.write(json.dumps(files))
 

--- a/wfssrv/wfssrv.py
+++ b/wfssrv/wfssrv.py
@@ -525,7 +525,7 @@ class WFSServ(tornado.web.Application):
 
         if os.path.isdir(self.datadir):
             logfile = os.path.join(self.datadir, "wfs.log")
-            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+            formatter = logging.Formatter("%(color)s%(asctime)s - %(name)s - %(levelname)s - %(message)s%(end_color)s")
             handler = logging.handlers.WatchedFileHandler(logfile)
             handler.setFormatter(formatter)
             logger.addHandler(handler)

--- a/wfssrv/wfssrv.py
+++ b/wfssrv/wfssrv.py
@@ -193,7 +193,6 @@ class WFSServ(tornado.web.Application):
                     figures['totalforces'] = tel.plot_forces(totforces, totm1focus)
                     figures['totalforces'].set_label("Total M1 Actuator Forces")
                     psf, figures['psf'] = tel.psf(zv=zvec.copy())
-                    log.info(zvec)
                     log.info("Residual RMS: %.2f nm" % zresults['residual_rms'].value)
                     zvec_file = os.path.join(self.application.datadir, filename + ".zernike")
                     zvec.save(filename=zvec_file)

--- a/wfssrv/wfssrv.py
+++ b/wfssrv/wfssrv.py
@@ -203,7 +203,7 @@ class WFSServ(tornado.web.Application):
                     if zresults['residual_rms'] < 600 * u.nm:
                         self.application.has_pending_m1 = True
                         self.application.has_pending_coma = True
-                        log.info("%s: all corrections valid." % filename)
+                        log.info("%s: all proposed corrections valid." % filename)
                     elif zresults['residual_rms'] <= 1000 * u.nm:
                         self.application.has_pending_focus = True
                         log.warning("%s: only focus corrections valid." % filename)
@@ -233,13 +233,16 @@ class WFSServ(tornado.web.Application):
                         )
                     )
                 else:
-                    log.warning("Wavefront measurement failed: %s" % filename)
+                    log.error("Wavefront measurement failed: %s" % filename)
                     figures = create_default_figures()
                     figures['slopes'] = results['figures']['slopes']
 
                 self.application.refresh_figures(figures=figures)
             else:
                 log.error("No such file: %s" % filename)
+
+            self.application.wavefront_fit.denormalize()
+            self.write(json.dumps(repr(self.application.wavefront_fit)))
 
     class M1CorrectHandler(tornado.web.RequestHandler):
         def get(self):


### PR DESCRIPTION
This PR adds the controls and hooks to the web interface to facilitate continuous WFS. It also adds a logging window to the interface that gets updated in near-real time via a WebSocket. Other interface tweaks were made as well as an improvement in the handler that lists WFS FITS files. It now provides a list sorted by creation time rather than filename. A small tweak was also made to the MMIRS pupil config to help reject some of the faint spots whose lenslets fall mostly off the pupil. 