### PR TITLE
Add benchmarking to tests

### DIFF
--- a/.github/workflows/mmtwfs-tests.yml
+++ b/.github/workflows/mmtwfs-tests.yml
@@ -23,11 +23,8 @@ jobs:
           pytest: false
         - linux: py313-alldeps-cov
           name: py313
-        - linux: py313-astropydev
-          name: py313-astropy-latest
-          continue-on-error: true
-        - linux: py313-numpydev
-          name: py313-numpy-latest
+        - linux: py313-devdeps
+          name: py313-devdeps
           continue-on-error: true
         - linux: build_docs
       coverage: 'codecov'

--- a/mmtwfs/tests/test_wfs.py
+++ b/mmtwfs/tests/test_wfs.py
@@ -16,6 +16,13 @@ from mmtwfs.custom_exceptions import WFSConfigException, WFSCommandException
 WFS_DATA_DIR = importlib.resources.files("mmtwfs") / "data"
 
 
+def _analyze_image(wfs, test_file):
+    results = wfs.measure_slopes(test_file)
+    zresults = wfs.fit_wavefront(results)
+    plt.close("all")
+    return zresults
+
+
 def test_check_wfsdata():
     try:
         check_wfsdata("bogus.fits")
@@ -74,11 +81,10 @@ def test_make_mask():
     assert mask.min() == 0.0
 
 
-def test_mmirs_analysis():
+def test_mmirs_analysis(benchmark):
     test_file = WFS_DATA_DIR / "test_data" / "mmirs_wfs_0150.fits"
     mmirs = WFSFactory(wfs="mmirs")
-    results = mmirs.measure_slopes(test_file)
-    zresults = mmirs.fit_wavefront(results)
+    zresults = benchmark(_analyze_image, mmirs, test_file)
     testval = int(zresults["zernike"]["Z10"].value)
     assert (testval > 416) & (testval < 436)
     plt.close("all")
@@ -133,51 +139,46 @@ def test_mmirs_bogus_pupil_mask():
         assert False
 
 
-def test_f9_analysis():
+def test_f9_analysis(benchmark):
     test_file = WFS_DATA_DIR / "test_data" / "TREX_p500_0000.fits"
     f9 = WFSFactory(wfs="f9")
-    results = f9.measure_slopes(test_file)
-    zresults = f9.fit_wavefront(results)
+    zresults = benchmark(_analyze_image, f9, test_file)
     testval = int(zresults["zernike"]["Z09"].value)
     assert (testval > 440) & (testval < 450)
     plt.close("all")
 
 
-def test_newf9_analysis():
+def test_newf9_analysis(benchmark):
     test_file = WFS_DATA_DIR / "test_data" / "test_newf9.fits"
     f9 = WFSFactory(wfs="newf9")
-    results = f9.measure_slopes(test_file)
-    zresults = f9.fit_wavefront(results)
+    zresults = benchmark(_analyze_image, f9, test_file)
     testval = int(zresults["zernike"]["Z09"].value)
     assert (testval > 109) & (testval < 129)
     plt.close("all")
 
 
-def test_f5_analysis():
+def test_f5_analysis(benchmark):
     test_file = WFS_DATA_DIR / "test_data" / "auto_wfs_0037_ave.fits"
     f5 = WFSFactory(wfs="f5")
-    results = f5.measure_slopes(test_file)
-    zresults = f5.fit_wavefront(results)
+    zresults = benchmark(_analyze_image, f5, test_file)
     testval = int(zresults["zernike"]["Z10"].value)
     assert (testval > 76) & (testval < 96)
     plt.close("all")
 
 
-def test_bino_analysis():
+def test_bino_analysis(benchmark):
     test_file = WFS_DATA_DIR / "test_data" / "wfs_ff_cal_img_2017.1113.111402.fits"
     wfs = WFSFactory(wfs="binospec")
-    results = wfs.measure_slopes(test_file, mode="binospec")
-    zresults = wfs.fit_wavefront(results)
+    zresults = benchmark(_analyze_image, wfs, test_file)
     testval = int(zresults["zernike"]["Z10"].value)
     assert (testval > 163) & (testval < 183)
     plt.close("all")
 
 
-def test_flwo_analysis():
+def test_flwo_analysis(benchmark):
     test_file = WFS_DATA_DIR / "test_data" / "1195.star.p2m18.fits"
     wfs = WFSFactory(wfs="flwo15")
-    results = wfs.measure_slopes(test_file)
-    zresults = wfs.fit_wavefront(results)
+    zresults = benchmark(_analyze_image, wfs, test_file)
     testval = int(zresults["zernike"]["Z06"].value)
     assert (testval > 700) & (testval < 1000)
     plt.close("all")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ test = [
     "pytest-astropy",
     "black",
     "flake8",
-    "coverage"
+    "coverage",
+    "pytest-benchmark",
 ]
 docs = [
     "sphinx-astropy",
@@ -78,7 +79,7 @@ testpaths = [
     "mmtwfs/tests",
     "docs",
 ]
-astropy_header = true
+astropy_header = false
 doctest_plus = "enabled"
 text_file_format = "rst"
 addopts = [

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     devdeps: astropy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
+    devdeps: scikit-image>=0.0.dev0
 
 # need to have run tests before making coverage report
 depends =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{312,313}{,-alldeps}{,-cov}
-    py{312,313}-{numpy,astropy}dev
+    py{312,313}{,-alldeps,-devdeps}{,-cov}
     build_docs
     linkcheck
     codestyle
@@ -17,9 +16,13 @@ usedevelop = False
 # Pass through the following environemnt variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
 
+# Set variable to point to the nightly wheels for dev dependencies
+setenv =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
-changedir = {toxworkdir}/tox_testing
+changedir = .tmp/{envname}
 
 # tox environments are constructued with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -33,12 +36,14 @@ description =
     run tests
     cov: with coverage enabled
     alldeps: with all optional dependencies
-    {numpy,astropy}dev: with latest master from github repo
+    devdeps: with nightly wheels of cores dependencies
     cov_report: generate HTML coverage report
 
 deps =
-    numpydev: git+https://github.com/numpy/numpy.git#egg=numpy
-    astropydev: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: numpy>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
+    devdeps: scipy>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
 
 # need to have run tests before making coverage report
 depends =


### PR DESCRIPTION
This PR adds benchmarking to the tests that do full analysis of the test images. This will help track if code or dependency changes affect performance at all. This PR also refactors how development versions of dependencies are handled. The nightly wheels of the packages are used instead of installing from github. 