### PR TITLE
Update f/9 effective wavelength; add benchmarking to tests

### DIFF
--- a/mmtwfs/config.py
+++ b/mmtwfs/config.py
@@ -340,7 +340,7 @@ mmtwfs_config = {
             "secondary": "f9",
             "default_mode": "blue",
             # effective wavelength of the thruput response of the system
-            "eff_wave": 600 * u.nm,
+            "eff_wave": 760 * u.nm,
             "lampsrv": "_lampbox._tcp.mmto.arizona.edu",
             "cor_coords": [376.0, 434.0],
             "find_fwhm": 12.0,


### PR DESCRIPTION
The f/9 WFS was visually verified to still have its RG610 filter installed. It was thought that this was removed when the original apogee camera was replaced with the current SBIG one in 2016. It turns out that the filter is integrated with the WFS optics themselves behind the collimating lens. 

This PR also adds benchmarking to the tests that run a full WFS analysis. This will help track performance impacts of changes in the code and changes in dependencies. 